### PR TITLE
Rails Appに最低限必要な設定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem 'mysql2'
 # Webpack for rails
 gem 'webpacker', '~> 5.2'
 
+# i18n
+gem 'rails-i18n', '~> 6.0.0'
+
 gem 'bootsnap', require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.6)
       actionpack (= 6.0.3.6)
       activesupport (= 6.0.3.6)
@@ -247,6 +250,7 @@ DEPENDENCIES
   pry-rails
   puma
   rails (= 6.0.3.6)
+  rails-i18n (~> 6.0.0)
   rspec-rails
   rubocop
   rubocop-performance

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,6 @@
 require_relative 'boot'
 
 require 'rails'
-# Pick the frameworks you want:
 require 'active_model/railtie'
 require 'active_job/railtie'
 require 'active_record/railtie'
@@ -14,27 +13,20 @@ require 'action_mailbox/engine'
 require 'action_text/engine'
 require 'action_view/railtie'
 require 'action_cable/engine'
-# require "sprockets/railtie"
-# require "rails/test_unit/railtie"
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module TasksManagerServer
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
-
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.add_autoload_paths_to_load_path = false
+
+    # Set Timezone
+    config.time_zone = 'Tokyo'
+
+    # Set i18n default locale
+    config.i18n.default_locale = :ja
 
     # Generate test framework
     config.generators do |g|


### PR DESCRIPTION
## 概要

Rails Appに最低限必要な設定を追加した

## やったこと

- [x] Rails6はzeitwerkモードなので、`config.add_autoload_paths_to_load_path = false`に設定
- [x] タイムゾーンを`'Tokyo'`に設定
- [x] i18のデフォルトロケールを`ja`に設定
- [x] rails-i18nを導入
